### PR TITLE
Update retrieval qa function to lcel

### DIFF
--- a/src/rag_chain.py
+++ b/src/rag_chain.py
@@ -1,12 +1,34 @@
-from langchain.chains import RetrievalQA
 from langchain_openai import ChatOpenAI
+from langchain import hub
+from langchain.chains import create_retrieval_chain
+from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough, RunnableLambda
+
 def run_qa_chain(vector_store):
     retriever = vector_store.as_retriever(search_kwargs={"k":4})
     llm = ChatOpenAI(temperature=0.1)
 
-    qa_chain = RetrievalQA.from_chain_type(
-        llm=llm,
-        retriever=retriever,
-        return_source_documents=True
+    try:
+        retrieval_qa_chat_prompt = hub.pull("langchain-ai/retrieval-qa-chat")
+    except Exception:
+        retrieval_qa_chat_prompt = ChatPromptTemplate.from_messages([
+            ("system", "You are a helpful assistant. Use the provided context to answer the user's question. If you don't know, say you don't know."),
+            ("human", "Context:\n{context}\n\nQuestion: {input}")
+        ])
+
+    combine_docs_chain = create_stuff_documents_chain(llm, retrieval_qa_chat_prompt)
+    rag_chain = create_retrieval_chain(retriever, combine_docs_chain)
+
+    # Accept string input directly and return a legacy-compatible output shape
+    # {'query': str, 'result': str, 'source_documents': list[Document]}
+    rag_chain_legacy = (
+        {"input": RunnablePassthrough()}
+        | rag_chain
+        | RunnableLambda(lambda x: {
+            "query": x.get("input"),
+            "result": x.get("answer"),
+            "source_documents": x.get("context"),
+        })
     )
-    return qa_chain
+    return rag_chain_legacy


### PR DESCRIPTION
Migrate `RetrievalQA` to LCEL-based `create_retrieval_chain` for improved customizability and future-proofing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6de0305-7ba2-4162-bbf2-a482b239f0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6de0305-7ba2-4162-bbf2-a482b239f0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

